### PR TITLE
Fix right-click quit to exit with status 0

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -468,7 +468,7 @@ fn activate(application: &gtk::Application) {
     // Assign your handler to an event of the gesture (e.g. the `pressed` event)
     right_click_mouse.connect_pressed(|_, _, _, _| {
         // exit the application
-        std::process::exit(1);
+        std::process::exit(0);
     });
 
     draw.add_controller(right_click_mouse);


### PR DESCRIPTION
The right-click gesture is the documented way to exit the overlay, so it represents a successful, user-initiated termination. Calling `std::process::exit(1)` poisons shells, scripts, and service managers that distinguish failure from clean shutdown. Use exit(0) instead.