### PR TITLE
Fix highlighter rendering: missing initial point, last segment, and s…

### DIFF
--- a/src/drawing/highlighter.rs
+++ b/src/drawing/highlighter.rs
@@ -36,12 +36,22 @@ impl Highlighter {
 }
 
 impl DrawingTool for Highlighter {
-    fn release_mouse(&mut self, _: Point) {
+    fn release_mouse(&mut self, point: Point) {
+        if self.active() {
+            if let Some(last) = self.points.last() {
+                if last.0 != point.0 || last.1 != point.1 {
+                    self.points.push(point);
+                }
+            } else {
+                self.points.push(point);
+            }
+        }
         self.finished = true;
     }
 
-    fn press_mouse(&mut self, _: Point) {
+    fn press_mouse(&mut self, point: Point) {
         self.started = true;
+        self.points.push(point);
     }
 
     fn motion_notify(&mut self, point: Point) {
@@ -51,6 +61,10 @@ impl DrawingTool for Highlighter {
     }
 
     fn draw(&self, ctx: &Context) {
+        if self.points.is_empty() {
+            return;
+        }
+
         let color = self.color;
         ctx.set_source_rgba(
             color.red().into(),
@@ -62,25 +76,62 @@ impl DrawingTool for Highlighter {
         ctx.set_line_cap(gtk::cairo::LineCap::Round);
         ctx.set_line_join(gtk::cairo::LineJoin::Round);
 
-        if self.points.len() > 3 {
-            let controls = calc_whole_spline(&self.points);
-            let first_point = self.points[0];
-            ctx.move_to(first_point.0, first_point.1);
-            for i in 0..self.points.len() - 2 {
-                let p_0 = self.points[i];
-                let p_1 = self.points[i + 1];
-                ctx.curve_to(
-                    p_0.0 + controls[i].0,
-                    p_0.1 + controls[i].1,
-                    p_1.0 - controls[i + 1].0,
-                    p_1.1 - controls[i + 1].1,
-                    p_1.0,
-                    p_1.1,
-                )
+        let n = self.points.len();
+
+        if n == 1 {
+            let p = self.points[0];
+            ctx.arc(p.0, p.1, self.line_width / 2.0, 0.0, std::f64::consts::TAU);
+            if let Err(e) = ctx.fill() {
+                panic!("{e}");
             }
+            return;
+        }
+
+        if n == 2 {
+            ctx.move_to(self.points[0].0, self.points[0].1);
+            ctx.line_to(self.points[1].0, self.points[1].1);
             if let Err(e) = ctx.stroke() {
-                panic!("{e}")
+                panic!("{e}");
             }
+            return;
+        }
+
+        if n == 3 {
+            let p0 = self.points[0];
+            let p1 = self.points[1];
+            let p2 = self.points[2];
+            ctx.move_to(p0.0, p0.1);
+            ctx.curve_to(
+                p0.0 + (p1.0 - p0.0) * 0.5,
+                p0.1 + (p1.1 - p0.1) * 0.5,
+                p1.0 + (p2.0 - p1.0) * 0.5,
+                p1.1 + (p2.1 - p1.1) * 0.5,
+                p2.0,
+                p2.1,
+            );
+            if let Err(e) = ctx.stroke() {
+                panic!("{e}");
+            }
+            return;
+        }
+
+        let controls = calc_whole_spline(&self.points);
+        let first_point = self.points[0];
+        ctx.move_to(first_point.0, first_point.1);
+        for i in 0..n - 1 {
+            let p_0 = self.points[i];
+            let p_1 = self.points[i + 1];
+            ctx.curve_to(
+                p_0.0 + controls[i].0,
+                p_0.1 + controls[i].1,
+                p_1.0 - controls[i + 1].0,
+                p_1.1 - controls[i + 1].1,
+                p_1.0,
+                p_1.1,
+            );
+        }
+        if let Err(e) = ctx.stroke() {
+            panic!("{e}");
         }
     }
 


### PR DESCRIPTION
…hort strokes

The highlighter previously had three issues that combined to drop or truncate strokes:

1. press_mouse did not push the initial point (only set started=true). A click without motion produced an empty points vector and rendered nothing.
2. release_mouse did not push the release point, so the very last bit of motion was discarded.
3. The draw loop iterated `0..points.len() - 2`, drawing segments only up to the second-to-last point and silently dropping the final segment of every stroke. NormalLine uses `0..n - 1` for the same spline.
4. The draw path was gated on `points.len() > 3` with no fallback, so strokes of 1, 2, or 3 points never rendered at all.

This commit mirrors NormalLine: the initial point is captured on press, the release point is captured on release (deduped against the last point), and the draw path handles the 1, 2, 3, and >=4 point cases explicitly. The B-spline branch now uses the correct `0..n - 1` bound.