### PR TITLE
Fix keyboard color chooser to seed dialog with current color

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -388,7 +388,7 @@ fn activate(application: &gtk::Application) {
                     w.set_layer(Layer::Bottom);
                     color_dialog.choose_rgba(
                         None::<&gtk::Window>,
-                        Some(&gtk::gdk::RGBA::RED),
+                        Some(&*color.borrow()),
                         None::<&gio::Cancellable>,
                         glib::clone!(
                             #[strong]


### PR DESCRIPTION
The color-chooser keybinding handler called `choose_rgba` with `Some(&gtk::gdk::RGBA::RED)` as the initial color, so the dialog always reset to red regardless of what the user had selected via the toolbar swatch, the preset keys (r/g/b), the toolbar presets, or a prior color-chooser invocation.

The toolbar swatch handler already passes `Some(&*color.borrow())`, which is the correct initial value. Use the same here so the dialog opens on the user's current color.