### PR TITLE
Stop shift toggling constraint on finished shapes

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -247,7 +247,9 @@ fn activate(application: &gtk::Application) {
             let is_shift = modifier.contains(gtk::gdk::ModifierType::SHIFT_MASK);
             *shift_held.borrow_mut() = is_shift;
             if let Some(elem) = elements.borrow_mut().last_mut() {
-                elem.set_constrained(is_shift);
+                if elem.active() {
+                    elem.set_constrained(is_shift);
+                }
             }
             draw.queue_draw();
             if *text_input_mode.borrow() {
@@ -432,7 +434,9 @@ fn activate(application: &gtk::Application) {
             let is_shift = modifier.contains(gtk::gdk::ModifierType::SHIFT_MASK);
             *shift_held.borrow_mut() = is_shift;
             if let Some(elem) = elements.borrow_mut().last_mut() {
-                elem.set_constrained(is_shift);
+                if elem.active() {
+                    elem.set_constrained(is_shift);
+                }
             }
             draw.queue_draw();
         },


### PR DESCRIPTION
The shift modifier listener mutated the constraint of the last element in the stack on every press/release, regardless of whether that element was still being drawn. Once an arrow or rectangle was released, holding or releasing shift afterwards re-toggled its `constrained` field, which `draw()` evaluates every frame. Pressing shift after finishing an unsnapped shape would silently re-snap it, and releasing shift after finishing a snapped shape would undo the snap the user committed to.

Gate the constraint update on `elem.active()` so the modifier only affects the in-progress shape and finished geometry stays as the user released it.