### PR TITLE
Extract geometry utilities to `geometry` module, add tests, and update CI to check tests

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -41,6 +41,9 @@ jobs:
   fedora-test:
      runs-on: ubuntu-latest
      container: ghcr.io/gtk-rs/gtk4-rs/gtk4:latest
+     env:
+       PKG_CONFIG_PATH: /usr/local/lib/pkgconfig
+       LD_LIBRARY_PATH: /usr/local/lib
      steps:
      - uses: actions/checkout@v3
      - run: git clone https://github.com/wmww/gtk4-layer-shell
@@ -48,10 +51,10 @@ jobs:
      # - run: sudo apt install meson libwayland-dev libgtk-4-dev gobject-introspection libgirepository1.0-dev gtk-doc-tools valac
      - run: cd gtk4-layer-shell && meson setup -Dexamples=true -Ddocs=true -Dtests=true build && ninja -C build && sudo ninja -C build install && sudo ldconfig
      - run: sudo dnf install rust cargo -y
-     - run: export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig
-     - run: export LD_LIBRARY_PATH=/usr/local/lib
      - name: Build
        run: cargo build --verbose
+     - name: Check test targets compile
+       run: cargo check --tests --verbose
      - name: Run tests
        run: cargo test --verbose
        #ghcr.io/gtk-rs/gtk4-rs/gtk4:latest

--- a/src/config.rs
+++ b/src/config.rs
@@ -151,3 +151,47 @@ fn read_config_file(file_path: &std::path::Path) -> Result<Configuration, Error>
 
     Ok(config.merge(Configuration::default()))
 }
+
+
+#[cfg(test)]
+mod tests {
+    use super::Configuration;
+
+    #[test]
+    fn merge_prefers_present_values_and_falls_back_to_defaults_source() {
+        let primary = Configuration {
+            line_thickness: Some(9.0),
+            draw_keybind: None,
+            arrow_keybind: Some("a".to_string()),
+            reverse_arrow_keybind: None,
+            rectangle_keybind: None,
+            text_keybind: Some("t".to_string()),
+            highlighter_keybind: None,
+            disable_drawing: None,
+            color_r: Some("R".to_string()),
+            color_g: None,
+            color_b: None,
+            color_chooser: None,
+            undo: Some("u".to_string()),
+            clear_all: None,
+        };
+
+        let fallback = Configuration::default();
+        let merged = primary.merge(fallback);
+
+        assert_eq!(merged.line_thickness, Some(9.0));
+        assert_eq!(merged.arrow_keybind, Some("a".to_string()));
+        assert_eq!(merged.text_keybind, Some("t".to_string()));
+        assert_eq!(merged.color_r, Some("R".to_string()));
+        assert_eq!(merged.undo, Some("u".to_string()));
+        assert_eq!(merged.draw_keybind, Some("1".to_string()));
+        assert_eq!(merged.reverse_arrow_keybind, Some("3".to_string()));
+        assert_eq!(merged.rectangle_keybind, Some("4".to_string()));
+        assert_eq!(merged.highlighter_keybind, Some("6".to_string()));
+        assert_eq!(merged.disable_drawing, Some("d".to_string()));
+        assert_eq!(merged.color_g, Some("g".to_string()));
+        assert_eq!(merged.color_b, Some("b".to_string()));
+        assert_eq!(merged.color_chooser, Some("c".to_string()));
+        assert_eq!(merged.clear_all, Some("x".to_string()));
+    }
+}

--- a/src/drawing/drawing_tool.rs
+++ b/src/drawing/drawing_tool.rs
@@ -3,47 +3,7 @@ use std::any::Any;
 use gtk::cairo::Context;
 
 use crate::colors;
-
-#[derive(Clone, Debug, Copy)]
-pub struct Point(pub f64, pub f64);
-
-impl std::ops::Add<Point> for Point {
-    type Output = Point;
-
-    fn add(self, rhs: Point) -> Self::Output {
-        Point(self.0 + rhs.0, self.1 + rhs.1)
-    }
-}
-impl std::ops::Sub<Point> for Point {
-    type Output = Point;
-
-    fn sub(self, rhs: Point) -> Self::Output {
-        Point(self.0 - rhs.0, self.1 - rhs.1)
-    }
-}
-impl std::ops::Mul<f64> for Point {
-    type Output = Point;
-
-    fn mul(self, rhs: f64) -> Self::Output {
-        Point(self.0 * rhs, self.1 * rhs)
-    }
-}
-
-impl std::ops::Div<f64> for Point {
-    type Output = Point;
-
-    fn div(self, rhs: f64) -> Self::Output {
-        Point(self.0 / rhs, self.1 / rhs)
-    }
-}
-
-impl std::ops::Neg for Point {
-    type Output = Point;
-
-    fn neg(self) -> Point {
-        Point(-self.0, -self.1)
-    }
-}
+pub use crate::geometry::{snap_angle, snap_square, Point};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CurrentDrawingTool {
@@ -53,22 +13,6 @@ pub enum CurrentDrawingTool {
     NormalRectangle,
     Highlighter,
     TextLabel,
-}
-
-pub fn snap_angle(start: Point, end: Point) -> Point {
-    let dx = end.0 - start.0;
-    let dy = end.1 - start.1;
-    let angle = dy.atan2(dx);
-    let snapped = (angle / std::f64::consts::FRAC_PI_4).round() * std::f64::consts::FRAC_PI_4;
-    let len = (dx * dx + dy * dy).sqrt();
-    Point(start.0 + len * snapped.cos(), start.1 + len * snapped.sin())
-}
-
-pub fn snap_square(start: Point, end: Point) -> Point {
-    let dx = end.0 - start.0;
-    let dy = end.1 - start.1;
-    let side = dx.abs().max(dy.abs());
-    Point(start.0 + side * dx.signum(), start.1 + side * dy.signum())
 }
 
 pub trait DrawingTool {

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -1,0 +1,56 @@
+#[derive(Clone, Debug, Copy)]
+pub struct Point(pub f64, pub f64);
+
+impl std::ops::Add<Point> for Point {
+    type Output = Point;
+
+    fn add(self, rhs: Point) -> Self::Output {
+        Point(self.0 + rhs.0, self.1 + rhs.1)
+    }
+}
+impl std::ops::Sub<Point> for Point {
+    type Output = Point;
+
+    fn sub(self, rhs: Point) -> Self::Output {
+        Point(self.0 - rhs.0, self.1 - rhs.1)
+    }
+}
+impl std::ops::Mul<f64> for Point {
+    type Output = Point;
+
+    fn mul(self, rhs: f64) -> Self::Output {
+        Point(self.0 * rhs, self.1 * rhs)
+    }
+}
+
+impl std::ops::Div<f64> for Point {
+    type Output = Point;
+
+    fn div(self, rhs: f64) -> Self::Output {
+        Point(self.0 / rhs, self.1 / rhs)
+    }
+}
+
+impl std::ops::Neg for Point {
+    type Output = Point;
+
+    fn neg(self) -> Point {
+        Point(-self.0, -self.1)
+    }
+}
+
+pub fn snap_angle(start: Point, end: Point) -> Point {
+    let dx = end.0 - start.0;
+    let dy = end.1 - start.1;
+    let angle = dy.atan2(dx);
+    let snapped = (angle / std::f64::consts::FRAC_PI_4).round() * std::f64::consts::FRAC_PI_4;
+    let len = (dx * dx + dy * dy).sqrt();
+    Point(start.0 + len * snapped.cos(), start.1 + len * snapped.sin())
+}
+
+pub fn snap_square(start: Point, end: Point) -> Point {
+    let dx = end.0 - start.0;
+    let dy = end.1 - start.1;
+    let side = dx.abs().max(dy.abs());
+    Point(start.0 + side * dx.signum(), start.1 + side * dy.signum())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,2 @@
+pub mod config;
+pub mod geometry;

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ pub mod colors;
 pub mod config;
 pub mod cursors;
 pub mod drawing;
+pub mod geometry;
 pub mod toolbar;
 
 // https://github.com/wmww/gtk-layer-shell/blob/master/examples/simple-example.c

--- a/tests/config_tests.rs
+++ b/tests/config_tests.rs
@@ -1,0 +1,39 @@
+use gtk4_drawing_tool::config::Configuration;
+
+#[test]
+fn merge_prefers_present_values_and_falls_back_to_defaults_source() {
+    let primary = Configuration {
+        line_thickness: Some(9.0),
+        draw_keybind: None,
+        arrow_keybind: Some("a".to_string()),
+        reverse_arrow_keybind: None,
+        rectangle_keybind: None,
+        text_keybind: Some("t".to_string()),
+        highlighter_keybind: None,
+        disable_drawing: None,
+        color_r: Some("R".to_string()),
+        color_g: None,
+        color_b: None,
+        color_chooser: None,
+        undo: Some("u".to_string()),
+        clear_all: None,
+    };
+
+    let fallback = Configuration::default();
+    let merged = primary.merge(fallback);
+
+    assert_eq!(merged.line_thickness, Some(9.0));
+    assert_eq!(merged.arrow_keybind, Some("a".to_string()));
+    assert_eq!(merged.text_keybind, Some("t".to_string()));
+    assert_eq!(merged.color_r, Some("R".to_string()));
+    assert_eq!(merged.undo, Some("u".to_string()));
+    assert_eq!(merged.draw_keybind, Some("1".to_string()));
+    assert_eq!(merged.reverse_arrow_keybind, Some("3".to_string()));
+    assert_eq!(merged.rectangle_keybind, Some("4".to_string()));
+    assert_eq!(merged.highlighter_keybind, Some("6".to_string()));
+    assert_eq!(merged.disable_drawing, Some("d".to_string()));
+    assert_eq!(merged.color_g, Some("g".to_string()));
+    assert_eq!(merged.color_b, Some("b".to_string()));
+    assert_eq!(merged.color_chooser, Some("c".to_string()));
+    assert_eq!(merged.clear_all, Some("x".to_string()));
+}

--- a/tests/geometry_tests.rs
+++ b/tests/geometry_tests.rs
@@ -1,0 +1,42 @@
+use gtk4_drawing_tool::geometry::{snap_angle, snap_square, Point};
+
+const EPSILON: f64 = 1e-9;
+
+fn assert_point_close(actual: Point, expected: Point) {
+    assert!((actual.0 - expected.0).abs() < EPSILON);
+    assert!((actual.1 - expected.1).abs() < EPSILON);
+}
+
+#[test]
+fn point_arithmetic_operators_work() {
+    let left = Point(5.0, -2.0);
+    let right = Point(2.0, 6.0);
+
+    assert_point_close(left + right, Point(7.0, 4.0));
+    assert_point_close(left - right, Point(3.0, -8.0));
+    assert_point_close(left * 2.0, Point(10.0, -4.0));
+    assert_point_close(left / 2.0, Point(2.5, -1.0));
+    assert_point_close(-left, Point(-5.0, 2.0));
+}
+
+#[test]
+fn snap_angle_snaps_to_nearest_45_degree_angle() {
+    let start = Point(0.0, 0.0);
+    let end = Point(2.0, 1.0);
+
+    let snapped = snap_angle(start, end);
+
+    let expected_len = (2.0_f64.powi(2) + 1.0_f64.powi(2)).sqrt();
+    let expected = Point(expected_len * std::f64::consts::FRAC_1_SQRT_2, expected_len * std::f64::consts::FRAC_1_SQRT_2);
+    assert_point_close(snapped, expected);
+}
+
+#[test]
+fn snap_square_makes_square_in_negative_direction() {
+    let start = Point(5.0, 5.0);
+    let end = Point(2.0, 3.0);
+
+    let snapped = snap_square(start, end);
+
+    assert_point_close(snapped, Point(2.0, 2.0));
+}


### PR DESCRIPTION
### Motivation

- Separate reusable geometry primitives and helpers from the drawing tool to improve code organization and reuse. 
- Add unit and integration tests for geometry operations and configuration merging to catch regressions. 
- Ensure the Fedora CI job can find locally-installed libs and verify test targets compile before running tests.

### Description

- Added `src/geometry.rs` which defines `Point` with arithmetic operator implementations and the `snap_angle` and `snap_square` helpers. 
- Updated `src/drawing/drawing_tool.rs` to re-export `Point`, `snap_angle`, and `snap_square` from `crate::geometry` and removed the duplicate local implementations. 
- Added `src/lib.rs` to expose `config` and `geometry` as library modules so tests and other crates can import them. 
- Added tests: a unit test in `src/config.rs` and integration tests in `tests/geometry_tests.rs` and `tests/config_tests.rs` to validate geometry arithmetic, snapping behavior, and configuration merging. 
- Updated `.github/workflows/rust.yml` to set `PKG_CONFIG_PATH` and `LD_LIBRARY_PATH` for the `fedora-test` container and added a `cargo check --tests --verbose` step to verify test targets compile before running `cargo test`.

### Testing

- Ran `cargo check --tests` as configured in CI to confirm test targets compile, and it succeeded. 
- Ran `cargo test` which executed the new `geometry_tests` and `config_tests` and all tests passed. 
- The CI `fedora-test` job now sets `PKG_CONFIG_PATH` and `LD_LIBRARY_PATH` and performs the added `cargo check` before running tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11df302aec83259e79cda59e123869)