### PR TITLE
ci: strengthen Rust workflow with fmt, clippy, caching, release build, and Nix validation

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,61 +1,52 @@
-name: Rust
+name: Rust CI
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
 
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  # build:
-  #   runs-on: ubuntu-latest
-  #   container:
-  #     image: ghcr.io/gtk-rs/gtk4-rs/gtk4:latest
-  #   steps:
-  #   - uses: actions/checkout@v3
-  #   - name: Apt update
-  #     run: sudo apt update
-  #   - run: git clone https://github.com/wmww/gtk4-layer-shell
-  #   - run: sudo apt install meson libwayland-dev libgtk-4-dev gobject-introspection libgirepository1.0-dev gtk-doc-tools valac
-  #   - run: cd gtk4-layer-shell && meson setup -Dexamples=true -Ddocs=true -Dtests=true build && ninja -C build && sudo ninja -C build install && sudo ldconfig
-  #   - run: export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig
-  #   - run: export LD_LIBRARY_PATH=/usr/local/lib
-  #   - run: cd ..
-  #   - name: Build
-  #     run: cargo build --verbose
-  #   - name: Run tests
-  #     run: cargo test --verbose
+  fedora-ci:
+    name: Fedora checks
+    runs-on: ubuntu-latest
+    container: ghcr.io/gtk-rs/gtk4-rs/gtk4:latest
+    steps:
+      - uses: actions/checkout@v4
 
-  # apline-test:
-  #    runs-on: ubuntu-latest
-  #    container: alpine:edge
-  #    steps:
-  #    - uses: actions/checkout@v3
-  #    - run: apk --no-cache add git gcc g++ cmake binutils pkgconf meson ninja wayland-dev wayland-protocols libinput-dev libevdev-dev gtk4.0 gtk-doc vala rust cargo gdk-pixbuf
-  #    - run: apk add gtk4-layer-shell --update-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing/ --allow-untrusted
-  #    # - run: export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig
-  #    # - run: export LD_LIBRARY_PATH=/usr/local/lib
-  #    - name: Build
-  #      run: cargo build --verbose
-  #    - name: Run tests
-       # run: cargo test --verbose
-  fedora-test:
-     runs-on: ubuntu-latest
-     container: ghcr.io/gtk-rs/gtk4-rs/gtk4:latest
-     env:
-       PKG_CONFIG_PATH: /usr/local/lib/pkgconfig
-       LD_LIBRARY_PATH: /usr/local/lib
-     steps:
-     - uses: actions/checkout@v3
-     - run: git clone https://github.com/wmww/gtk4-layer-shell
-     - run: sudo dnf install vala gtk-doc -y
-     # - run: sudo apt install meson libwayland-dev libgtk-4-dev gobject-introspection libgirepository1.0-dev gtk-doc-tools valac
-     - run: cd gtk4-layer-shell && meson setup -Dexamples=true -Ddocs=true -Dtests=true build && ninja -C build && sudo ninja -C build install && sudo ldconfig
-     - run: sudo dnf install rust cargo -y
-     - name: Build
-       run: cargo build --verbose
-     - name: Check test targets compile
-       run: cargo check --tests --verbose
-     - name: Run tests
-       run: cargo test --verbose
-       #ghcr.io/gtk-rs/gtk4-rs/gtk4:latest
+      - name: Install system dependencies
+        run: |
+          sudo dnf install -y \
+            rust cargo \
+            gtk4-layer-shell-devel
 
+      - name: Cache Rust artifacts
+        uses: Swatinem/rust-cache@v2
+
+      - name: Format check
+        run: cargo fmt --check
+
+      - name: Clippy
+        run: cargo clippy --all-targets -- -D warnings
+
+      - name: Tests (locked)
+        run: cargo test --locked --verbose
+
+      - name: Release build (locked)
+        run: cargo build --release --locked --verbose
+
+  nix-ci:
+    name: Nix validation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@main
+
+      - name: Cache Rust artifacts
+        uses: Swatinem/rust-cache@v2
+
+      - name: Run tests in nix-shell
+        run: nix-shell --run "cargo test --locked"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo dnf install -y \
-            rust cargo \
+            rust cargo rustfmt clippy \
             gtk4-layer-shell-devel
 
       - name: Cache Rust artifacts

--- a/src/config.rs
+++ b/src/config.rs
@@ -152,7 +152,6 @@ fn read_config_file(file_path: &std::path::Path) -> Result<Configuration, Error>
     Ok(config.merge(Configuration::default()))
 }
 
-
 #[cfg(test)]
 mod tests {
     use super::Configuration;

--- a/src/cursors.rs
+++ b/src/cursors.rs
@@ -4,7 +4,11 @@ use gtk::glib;
 const SIZE: i32 = 32;
 const OUTLINE: f64 = 2.5;
 
-fn surface_to_cursor(surface: &mut gtk::cairo::ImageSurface, hotspot_x: i32, hotspot_y: i32) -> Option<gdk::Cursor> {
+fn surface_to_cursor(
+    surface: &mut gtk::cairo::ImageSurface,
+    hotspot_x: i32,
+    hotspot_y: i32,
+) -> Option<gdk::Cursor> {
     surface.flush();
     let bytes = glib::Bytes::from(surface.data().ok()?.as_ref());
     let texture = gdk::MemoryTexture::new(
@@ -15,10 +19,7 @@ fn surface_to_cursor(surface: &mut gtk::cairo::ImageSurface, hotspot_x: i32, hot
         (SIZE * 4) as usize,
     );
     Some(gdk::Cursor::from_texture(
-        &texture,
-        hotspot_x,
-        hotspot_y,
-        None,
+        &texture, hotspot_x, hotspot_y, None,
     ))
 }
 
@@ -42,7 +43,8 @@ fn pencil_path(cr: &gtk::cairo::Context) {
 }
 
 pub fn pencil_cursor() -> Option<gdk::Cursor> {
-    let mut surface = gtk::cairo::ImageSurface::create(gtk::cairo::Format::ARgb32, SIZE, SIZE).ok()?;
+    let mut surface =
+        gtk::cairo::ImageSurface::create(gtk::cairo::Format::ARgb32, SIZE, SIZE).ok()?;
     {
         let cr = gtk::cairo::Context::new(&surface).ok()?;
         cr.set_antialias(gtk::cairo::Antialias::Best);
@@ -93,7 +95,16 @@ pub fn pencil_cursor() -> Option<gdk::Cursor> {
 }
 
 #[allow(clippy::too_many_arguments)]
-fn arrow_path(cr: &gtk::cairo::Context, x1: f64, y1: f64, x2: f64, y2: f64, head_len: f64, a1: f64, a2: f64) {
+fn arrow_path(
+    cr: &gtk::cairo::Context,
+    x1: f64,
+    y1: f64,
+    x2: f64,
+    y2: f64,
+    head_len: f64,
+    a1: f64,
+    a2: f64,
+) {
     cr.move_to(x1, y1);
     cr.line_to(x2, y2);
     cr.move_to(x2, y2);
@@ -103,7 +114,8 @@ fn arrow_path(cr: &gtk::cairo::Context, x1: f64, y1: f64, x2: f64, y2: f64, head
 }
 
 pub fn arrow_cursor() -> Option<gdk::Cursor> {
-    let mut surface = gtk::cairo::ImageSurface::create(gtk::cairo::Format::ARgb32, SIZE, SIZE).ok()?;
+    let mut surface =
+        gtk::cairo::ImageSurface::create(gtk::cairo::Format::ARgb32, SIZE, SIZE).ok()?;
     {
         let cr = gtk::cairo::Context::new(&surface).ok()?;
         cr.set_antialias(gtk::cairo::Antialias::Best);
@@ -151,7 +163,8 @@ fn crosshair_path(cr: &gtk::cairo::Context) {
 }
 
 pub fn rectangle_cursor() -> Option<gdk::Cursor> {
-    let mut surface = gtk::cairo::ImageSurface::create(gtk::cairo::Format::ARgb32, SIZE, SIZE).ok()?;
+    let mut surface =
+        gtk::cairo::ImageSurface::create(gtk::cairo::Format::ARgb32, SIZE, SIZE).ok()?;
     {
         let cr = gtk::cairo::Context::new(&surface).ok()?;
         cr.set_antialias(gtk::cairo::Antialias::Best);
@@ -197,7 +210,8 @@ fn ibeam_path(cr: &gtk::cairo::Context) {
 }
 
 pub fn text_cursor() -> Option<gdk::Cursor> {
-    let mut surface = gtk::cairo::ImageSurface::create(gtk::cairo::Format::ARgb32, SIZE, SIZE).ok()?;
+    let mut surface =
+        gtk::cairo::ImageSurface::create(gtk::cairo::Format::ARgb32, SIZE, SIZE).ok()?;
     {
         let cr = gtk::cairo::Context::new(&surface).ok()?;
         cr.set_antialias(gtk::cairo::Antialias::Best);
@@ -247,7 +261,8 @@ fn highlighter_tip() -> (i32, i32) {
 }
 
 pub fn highlighter_cursor() -> Option<gdk::Cursor> {
-    let mut surface = gtk::cairo::ImageSurface::create(gtk::cairo::Format::ARgb32, SIZE, SIZE).ok()?;
+    let mut surface =
+        gtk::cairo::ImageSurface::create(gtk::cairo::Format::ARgb32, SIZE, SIZE).ok()?;
     {
         let cr = gtk::cairo::Context::new(&surface).ok()?;
         cr.set_antialias(gtk::cairo::Antialias::Best);

--- a/src/drawing/normal_line.rs
+++ b/src/drawing/normal_line.rs
@@ -66,7 +66,9 @@ pub fn calc_whole_spline(points: &[Point]) -> Vec<Point> {
 
 impl DrawingTool for NormalLine {
     fn release_mouse(&mut self, point: Point) {
-        if self.active() && (self.points.is_empty() || distance_sq(self.points.last().unwrap(), &point) > 0.0) {
+        if self.active()
+            && (self.points.is_empty() || distance_sq(self.points.last().unwrap(), &point) > 0.0)
+        {
             self.points.push(point);
         }
         self.finished = true;

--- a/src/drawing/text_label.rs
+++ b/src/drawing/text_label.rs
@@ -84,9 +84,10 @@ impl DrawingTool for TextLabel {
                 );
 
                 let layout = gtk::pango::Layout::new(&pangocairo::functions::create_context(ctx));
-                let font_desc = gtk::pango::FontDescription::from_string(
-                    &format!("Sans {}", (self.line_width * 8.0) as i32),
-                );
+                let font_desc = gtk::pango::FontDescription::from_string(&format!(
+                    "Sans {}",
+                    (self.line_width * 8.0) as i32
+                ));
                 layout.set_font_description(Some(&font_desc));
                 layout.set_text(&self.text);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -133,7 +133,9 @@ fn activate(application: &gtk::Application) {
             let cursor = match tool {
                 drawing::drawing_tool::CurrentDrawingTool::NormalLine => pencil_cur.clone(),
                 drawing::drawing_tool::CurrentDrawingTool::NormalArrowHeadBase
-                | drawing::drawing_tool::CurrentDrawingTool::NormalArrowHeadPointer => arrow_cur.clone(),
+                | drawing::drawing_tool::CurrentDrawingTool::NormalArrowHeadPointer => {
+                    arrow_cur.clone()
+                }
                 drawing::drawing_tool::CurrentDrawingTool::NormalRectangle => rectangle_cur.clone(),
                 drawing::drawing_tool::CurrentDrawingTool::TextLabel => text_cur.clone(),
                 drawing::drawing_tool::CurrentDrawingTool::Highlighter => highlighter_cur.clone(),
@@ -178,8 +180,12 @@ fn activate(application: &gtk::Application) {
                         Ok(c) => {
                             w.set_layer(Layer::Overlay);
                             *color.borrow_mut() = c;
-                            toolbar.borrow().update(&current_tool.borrow(), &c, *line_width.borrow());
-                        },
+                            toolbar.borrow().update(
+                                &current_tool.borrow(),
+                                &c,
+                                *line_width.borrow(),
+                            );
+                        }
                         Err(_) => {
                             w.set_layer(Layer::Overlay);
                         }
@@ -200,7 +206,9 @@ fn activate(application: &gtk::Application) {
         line_width,
         move |rgba| {
             *color.borrow_mut() = rgba;
-            toolbar.borrow().update(&current_tool.borrow(), &rgba, *line_width.borrow());
+            toolbar
+                .borrow()
+                .update(&current_tool.borrow(), &rgba, *line_width.borrow());
         },
     ));
 
@@ -217,7 +225,9 @@ fn activate(application: &gtk::Application) {
             let mut width = line_width.borrow_mut();
             let new_width = *width + delta;
             *width = if new_width < 1.0 { 1.0 } else { new_width };
-            toolbar.borrow().update(&current_tool.borrow(), &color.borrow(), *width);
+            toolbar
+                .borrow()
+                .update(&current_tool.borrow(), &color.borrow(), *width);
         },
     ));
 
@@ -254,12 +264,21 @@ fn activate(application: &gtk::Application) {
             }
             draw.queue_draw();
             if *text_input_mode.borrow() {
-                let _draw_key = Key::from_name(conf.draw_keybind.as_deref().unwrap_or("")).unwrap_or(Key::Abelowdot);
-                let _arrow_key = Key::from_name(conf.arrow_keybind.as_deref().unwrap_or("")).unwrap_or(Key::Abelowdot);
-                let _reverse_arrow_key = Key::from_name(conf.reverse_arrow_keybind.as_deref().unwrap_or("")).unwrap_or(Key::Abelowdot);
-                let _rectangle_key = Key::from_name(conf.rectangle_keybind.as_deref().unwrap_or("")).unwrap_or(Key::Abelowdot);
-                let _text_key = Key::from_name(conf.text_keybind.as_deref().unwrap_or("")).unwrap_or(Key::Abelowdot);
-                let _highlighter_key = Key::from_name(conf.highlighter_keybind.as_deref().unwrap_or("")).unwrap_or(Key::Abelowdot);
+                let _draw_key = Key::from_name(conf.draw_keybind.as_deref().unwrap_or(""))
+                    .unwrap_or(Key::Abelowdot);
+                let _arrow_key = Key::from_name(conf.arrow_keybind.as_deref().unwrap_or(""))
+                    .unwrap_or(Key::Abelowdot);
+                let _reverse_arrow_key =
+                    Key::from_name(conf.reverse_arrow_keybind.as_deref().unwrap_or(""))
+                        .unwrap_or(Key::Abelowdot);
+                let _rectangle_key =
+                    Key::from_name(conf.rectangle_keybind.as_deref().unwrap_or(""))
+                        .unwrap_or(Key::Abelowdot);
+                let _text_key = Key::from_name(conf.text_keybind.as_deref().unwrap_or(""))
+                    .unwrap_or(Key::Abelowdot);
+                let _highlighter_key =
+                    Key::from_name(conf.highlighter_keybind.as_deref().unwrap_or(""))
+                        .unwrap_or(Key::Abelowdot);
 
                 let is_tool_switch = keyval == _draw_key
                     || keyval == _arrow_key
@@ -270,7 +289,10 @@ fn activate(application: &gtk::Application) {
 
                 if is_tool_switch || keyval == Key::Escape {
                     if let Some(elem) = elements.borrow_mut().last_mut() {
-                        if let Some(text_tool) = elem.as_any_mut().downcast_mut::<drawing::text_label::TextLabel>() {
+                        if let Some(text_tool) = elem
+                            .as_any_mut()
+                            .downcast_mut::<drawing::text_label::TextLabel>()
+                        {
                             text_tool.finish();
                         }
                     }
@@ -283,7 +305,10 @@ fn activate(application: &gtk::Application) {
                     match keyval {
                         Key::Return => {
                             if let Some(elem) = elements.borrow_mut().last_mut() {
-                                if let Some(text_tool) = elem.as_any_mut().downcast_mut::<drawing::text_label::TextLabel>() {
+                                if let Some(text_tool) =
+                                    elem.as_any_mut()
+                                        .downcast_mut::<drawing::text_label::TextLabel>()
+                                {
                                     text_tool.finish();
                                 }
                             }
@@ -291,7 +316,10 @@ fn activate(application: &gtk::Application) {
                         }
                         Key::BackSpace => {
                             if let Some(elem) = elements.borrow_mut().last_mut() {
-                                if let Some(text_tool) = elem.as_any_mut().downcast_mut::<drawing::text_label::TextLabel>() {
+                                if let Some(text_tool) =
+                                    elem.as_any_mut()
+                                        .downcast_mut::<drawing::text_label::TextLabel>()
+                                {
                                     text_tool.pop_char();
                                 }
                             }
@@ -301,7 +329,10 @@ fn activate(application: &gtk::Application) {
                             if let Some(c) = keyval.to_unicode() {
                                 if !c.is_control() {
                                     if let Some(elem) = elements.borrow_mut().last_mut() {
-                                        if let Some(text_tool) = elem.as_any_mut().downcast_mut::<drawing::text_label::TextLabel>() {
+                                        if let Some(text_tool) =
+                                            elem.as_any_mut()
+                                                .downcast_mut::<drawing::text_label::TextLabel>()
+                                        {
                                             text_tool.push_char(c);
                                         }
                                     }
@@ -315,58 +346,80 @@ fn activate(application: &gtk::Application) {
             }
 
             // close your eyes
-            let _draw_key = Key::from_name(conf.draw_keybind.as_deref().unwrap_or("")).unwrap_or(Key::Abelowdot);
-            let _arrow_key = Key::from_name(conf.arrow_keybind.as_deref().unwrap_or("")).unwrap_or(Key::Abelowdot);
-            let _reverse_arrow_key = Key::from_name(conf.reverse_arrow_keybind.as_deref().unwrap_or("")).unwrap_or(Key::Abelowdot);
-            let _rectangle_key = Key::from_name(conf.rectangle_keybind.as_deref().unwrap_or("")).unwrap_or(Key::Abelowdot);
-            let _text_key = Key::from_name(conf.text_keybind.as_deref().unwrap_or("")).unwrap_or(Key::Abelowdot);
-            let _highlighter_key = Key::from_name(conf.highlighter_keybind.as_deref().unwrap_or("")).unwrap_or(Key::Abelowdot);
-            let _disable_drawing_key = Key::from_name(conf.disable_drawing.as_deref().unwrap_or("")).unwrap_or(Key::Abelowdot);
-            let _color_r = Key::from_name(conf.color_r.as_deref().unwrap_or("")).unwrap_or(Key::Abelowdot);
-            let _color_g = Key::from_name(conf.color_g.as_deref().unwrap_or("")).unwrap_or(Key::Abelowdot);
-            let _color_b = Key::from_name(conf.color_b.as_deref().unwrap_or("")).unwrap_or(Key::Abelowdot);
-            let _color_chooser = Key::from_name(conf.color_chooser.as_deref().unwrap_or("")).unwrap_or(Key::Abelowdot);
-            let _undo_key = Key::from_name(conf.undo.as_deref().unwrap_or("")).unwrap_or(Key::Abelowdot);
-            let _clear_all_key = Key::from_name(conf.clear_all.as_deref().unwrap_or("")).unwrap_or(Key::Abelowdot);
+            let _draw_key = Key::from_name(conf.draw_keybind.as_deref().unwrap_or(""))
+                .unwrap_or(Key::Abelowdot);
+            let _arrow_key = Key::from_name(conf.arrow_keybind.as_deref().unwrap_or(""))
+                .unwrap_or(Key::Abelowdot);
+            let _reverse_arrow_key =
+                Key::from_name(conf.reverse_arrow_keybind.as_deref().unwrap_or(""))
+                    .unwrap_or(Key::Abelowdot);
+            let _rectangle_key = Key::from_name(conf.rectangle_keybind.as_deref().unwrap_or(""))
+                .unwrap_or(Key::Abelowdot);
+            let _text_key = Key::from_name(conf.text_keybind.as_deref().unwrap_or(""))
+                .unwrap_or(Key::Abelowdot);
+            let _highlighter_key =
+                Key::from_name(conf.highlighter_keybind.as_deref().unwrap_or(""))
+                    .unwrap_or(Key::Abelowdot);
+            let _disable_drawing_key =
+                Key::from_name(conf.disable_drawing.as_deref().unwrap_or(""))
+                    .unwrap_or(Key::Abelowdot);
+            let _color_r =
+                Key::from_name(conf.color_r.as_deref().unwrap_or("")).unwrap_or(Key::Abelowdot);
+            let _color_g =
+                Key::from_name(conf.color_g.as_deref().unwrap_or("")).unwrap_or(Key::Abelowdot);
+            let _color_b =
+                Key::from_name(conf.color_b.as_deref().unwrap_or("")).unwrap_or(Key::Abelowdot);
+            let _color_chooser = Key::from_name(conf.color_chooser.as_deref().unwrap_or(""))
+                .unwrap_or(Key::Abelowdot);
+            let _undo_key =
+                Key::from_name(conf.undo.as_deref().unwrap_or("")).unwrap_or(Key::Abelowdot);
+            let _clear_all_key =
+                Key::from_name(conf.clear_all.as_deref().unwrap_or("")).unwrap_or(Key::Abelowdot);
 
             match keyval {
                 // TOOLS
                 _ if _draw_key == keyval => {
-                    *current_tool.borrow_mut() = drawing::drawing_tool::CurrentDrawingTool::NormalLine;
+                    *current_tool.borrow_mut() =
+                        drawing::drawing_tool::CurrentDrawingTool::NormalLine;
                     if let Some(pencil_cur) = pencil_cur.clone() {
                         draw.set_cursor(Some(&pencil_cur));
                     }
-                },
+                }
                 _ if _arrow_key == keyval => {
-                    *current_tool.borrow_mut() = drawing::drawing_tool::CurrentDrawingTool::NormalArrowHeadPointer;
+                    *current_tool.borrow_mut() =
+                        drawing::drawing_tool::CurrentDrawingTool::NormalArrowHeadPointer;
                     if let Some(arrow_cur) = arrow_cur.clone() {
                         draw.set_cursor(Some(&arrow_cur));
                     }
                 }
                 _ if _reverse_arrow_key == keyval => {
-                    *current_tool.borrow_mut() = drawing::drawing_tool::CurrentDrawingTool::NormalArrowHeadBase;
+                    *current_tool.borrow_mut() =
+                        drawing::drawing_tool::CurrentDrawingTool::NormalArrowHeadBase;
                     if let Some(arrow_cur) = arrow_cur.clone() {
                         draw.set_cursor(Some(&arrow_cur));
                     }
                 }
                 _ if _rectangle_key == keyval => {
-                    *current_tool.borrow_mut() = drawing::drawing_tool::CurrentDrawingTool::NormalRectangle;
+                    *current_tool.borrow_mut() =
+                        drawing::drawing_tool::CurrentDrawingTool::NormalRectangle;
                     if let Some(rectangle_cur) = rectangle_cur.clone() {
                         draw.set_cursor(Some(&rectangle_cur));
                     }
-                },
+                }
                 _ if _text_key == keyval => {
-                    *current_tool.borrow_mut() = drawing::drawing_tool::CurrentDrawingTool::TextLabel;
+                    *current_tool.borrow_mut() =
+                        drawing::drawing_tool::CurrentDrawingTool::TextLabel;
                     if let Some(text_cur) = text_cur.clone() {
                         draw.set_cursor(Some(&text_cur));
                     }
-                },
+                }
                 _ if _highlighter_key == keyval => {
-                    *current_tool.borrow_mut() = drawing::drawing_tool::CurrentDrawingTool::Highlighter;
+                    *current_tool.borrow_mut() =
+                        drawing::drawing_tool::CurrentDrawingTool::Highlighter;
                     if let Some(highlighter_cur) = highlighter_cur.clone() {
                         draw.set_cursor(Some(&highlighter_cur));
                     }
-                },
+                }
                 _ if _disable_drawing_key == keyval => {
                     w.set_keyboard_mode(KeyboardMode::None);
                     if let Some(surface) = w.surface() {
@@ -374,19 +427,23 @@ fn activate(application: &gtk::Application) {
                     }
                     w.unmap();
                     w.map();
-                },
+                }
                 // colors
-                _ if _color_r == keyval =>  *color.borrow_mut() = colors::RED,
-                _ if _color_g == keyval =>  *color.borrow_mut() = colors::GREEN,
-                _ if _color_b == keyval =>  *color.borrow_mut() = colors::BLUE,
-                _ if _undo_key == keyval && modifier.contains(gtk::gdk::ModifierType::CONTROL_MASK) => {
+                _ if _color_r == keyval => *color.borrow_mut() = colors::RED,
+                _ if _color_g == keyval => *color.borrow_mut() = colors::GREEN,
+                _ if _color_b == keyval => *color.borrow_mut() = colors::BLUE,
+                _ if _undo_key == keyval
+                    && modifier.contains(gtk::gdk::ModifierType::CONTROL_MASK) =>
+                {
                     elements.borrow_mut().pop();
                     draw.queue_draw();
-                },
-                _ if _clear_all_key == keyval && modifier.contains(gtk::gdk::ModifierType::CONTROL_MASK) => {
+                }
+                _ if _clear_all_key == keyval
+                    && modifier.contains(gtk::gdk::ModifierType::CONTROL_MASK) =>
+                {
                     elements.borrow_mut().clear();
                     draw.queue_draw();
-                },
+                }
                 _ if _color_chooser == keyval => {
                     w.set_layer(Layer::Bottom);
                     color_dialog.choose_rgba(
@@ -408,18 +465,26 @@ fn activate(application: &gtk::Application) {
                                 Ok(c) => {
                                     w.set_layer(Layer::Overlay);
                                     *color.borrow_mut() = c;
-                                    toolbar.borrow().update(&current_tool.borrow(), &c, *line_width.borrow());
-                                },
+                                    toolbar.borrow().update(
+                                        &current_tool.borrow(),
+                                        &c,
+                                        *line_width.borrow(),
+                                    );
+                                }
                                 Err(_) => {
                                     w.set_layer(Layer::Overlay);
                                 }
                             },
                         ),
                     );
-                },
+                }
                 _ => (),
             };
-            toolbar.borrow().update(&current_tool.borrow(), &color.borrow(), *line_width.borrow());
+            toolbar.borrow().update(
+                &current_tool.borrow(),
+                &color.borrow(),
+                *line_width.borrow(),
+            );
             Propagation::Proceed
         },
     ));
@@ -501,7 +566,10 @@ fn activate(application: &gtk::Application) {
             {
                 let mut elems = elements.borrow_mut();
                 if let Some(elem) = elems.last_mut() {
-                    if let Some(text_tool) = elem.as_any_mut().downcast_mut::<drawing::text_label::TextLabel>() {
+                    if let Some(text_tool) = elem
+                        .as_any_mut()
+                        .downcast_mut::<drawing::text_label::TextLabel>()
+                    {
                         if text_tool.is_movable() {
                             text_tool.finalize();
                             draw.queue_draw();
@@ -510,20 +578,34 @@ fn activate(application: &gtk::Application) {
                     }
                 }
             }
-            let mut drawing_tool: Box<dyn drawing::drawing_tool::DrawingTool> = match *current_tool.borrow() {
-                drawing::drawing_tool::CurrentDrawingTool::NormalLine => Box::new(drawing::normal_line::NormalLine::new()),
-                drawing::drawing_tool::CurrentDrawingTool::NormalArrowHeadBase => Box::new(drawing::arrow::NormalArrow::new(true)),
-                drawing::drawing_tool::CurrentDrawingTool::NormalArrowHeadPointer => Box::new(drawing::arrow::NormalArrow::new(false)),
-                drawing::drawing_tool::CurrentDrawingTool::NormalRectangle => Box::new(drawing::normal_rectangle::NormalRectangle::new()),
-                drawing::drawing_tool::CurrentDrawingTool::Highlighter => Box::new(drawing::highlighter::Highlighter::new()),
-                drawing::drawing_tool::CurrentDrawingTool::TextLabel => {
-                    *text_input_mode.borrow_mut() = true;
-                    draw.grab_focus();
-                    Box::new(drawing::text_label::TextLabel::new())
-                },
-            };
+            let mut drawing_tool: Box<dyn drawing::drawing_tool::DrawingTool> =
+                match *current_tool.borrow() {
+                    drawing::drawing_tool::CurrentDrawingTool::NormalLine => {
+                        Box::new(drawing::normal_line::NormalLine::new())
+                    }
+                    drawing::drawing_tool::CurrentDrawingTool::NormalArrowHeadBase => {
+                        Box::new(drawing::arrow::NormalArrow::new(true))
+                    }
+                    drawing::drawing_tool::CurrentDrawingTool::NormalArrowHeadPointer => {
+                        Box::new(drawing::arrow::NormalArrow::new(false))
+                    }
+                    drawing::drawing_tool::CurrentDrawingTool::NormalRectangle => {
+                        Box::new(drawing::normal_rectangle::NormalRectangle::new())
+                    }
+                    drawing::drawing_tool::CurrentDrawingTool::Highlighter => {
+                        Box::new(drawing::highlighter::Highlighter::new())
+                    }
+                    drawing::drawing_tool::CurrentDrawingTool::TextLabel => {
+                        *text_input_mode.borrow_mut() = true;
+                        draw.grab_focus();
+                        Box::new(drawing::text_label::TextLabel::new())
+                    }
+                };
             drawing_tool.press_mouse(drawing::drawing_tool::Point(x, y));
-            if !matches!(*current_tool.borrow(), drawing::drawing_tool::CurrentDrawingTool::Highlighter) {
+            if !matches!(
+                *current_tool.borrow(),
+                drawing::drawing_tool::CurrentDrawingTool::Highlighter
+            ) {
                 drawing_tool.set_line_width(*line_width.borrow());
                 drawing_tool.set_color(*color.borrow());
             }
@@ -578,7 +660,9 @@ fn activate(application: &gtk::Application) {
                 }
                 draw.queue_draw();
             }
-            toolbar.borrow().update(&current_tool.borrow(), &color.borrow(), *width);
+            toolbar
+                .borrow()
+                .update(&current_tool.borrow(), &color.borrow(), *width);
             Propagation::Proceed
         },
     ));

--- a/src/toolbar.rs
+++ b/src/toolbar.rs
@@ -1,5 +1,5 @@
-use gtk::prelude::*;
 use gtk::glib;
+use gtk::prelude::*;
 
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -33,7 +33,12 @@ fn make_color_button(rgba: gtk::gdk::RGBA) -> gtk::Button {
     area.set_content_width(16);
     area.set_content_height(16);
     area.set_draw_func(move |_, ctx, w, h| {
-        ctx.set_source_rgba(rgba.red() as f64, rgba.green() as f64, rgba.blue() as f64, rgba.alpha() as f64);
+        ctx.set_source_rgba(
+            rgba.red() as f64,
+            rgba.green() as f64,
+            rgba.blue() as f64,
+            rgba.alpha() as f64,
+        );
         ctx.rectangle(0.0, 0.0, w as f64, h as f64);
         let _ = ctx.fill();
         ctx.set_source_rgb(1.0, 1.0, 1.0);
@@ -74,7 +79,10 @@ impl Toolbar {
                 btn.set_active(true);
             }
             container.append(&btn);
-            tool_buttons.push(ToolButton { button: btn, tool: *tool });
+            tool_buttons.push(ToolButton {
+                button: btn,
+                tool: *tool,
+            });
         }
 
         if let Some(first) = tool_buttons.first() {
@@ -98,7 +106,12 @@ impl Toolbar {
             swatch_color,
             move |_, ctx, width, height| {
                 let c = *swatch_color.borrow();
-                ctx.set_source_rgba(c.red() as f64, c.green() as f64, c.blue() as f64, c.alpha() as f64);
+                ctx.set_source_rgba(
+                    c.red() as f64,
+                    c.green() as f64,
+                    c.blue() as f64,
+                    c.alpha() as f64,
+                );
                 ctx.rectangle(0.0, 0.0, width as f64, height as f64);
                 let _ = ctx.fill();
 
@@ -176,7 +189,12 @@ impl Toolbar {
     }
 
     pub fn connect_swatch_clicked<F: Fn() + 'static>(&self, f: F) {
-        let swatch_btn = self.color_swatch.parent().unwrap().downcast::<gtk::Button>().unwrap();
+        let swatch_btn = self
+            .color_swatch
+            .parent()
+            .unwrap()
+            .downcast::<gtk::Button>()
+            .unwrap();
         swatch_btn.connect_clicked(move |_| f());
     }
 
@@ -184,9 +202,9 @@ impl Toolbar {
         let f = Rc::new(f);
         let presets = [colors::RED, colors::GREEN, colors::BLUE, colors::YELLOW];
 
-        let sep1_idx = self.tool_buttons.len(); // separator is at this index
-        // children order: [tool_buttons...] [sep1] [swatch_btn] [preset_btns...] [sep2] [thickness]
-        // preset buttons start at index: tool_buttons.len() + 1 (sep) + 1 (swatch) = len+2
+        // Children order: [tool_buttons...] [sep1] [swatch_btn] [preset_btns...] [sep2] [thickness]
+        // Preset buttons start at index: tool_buttons.len() + 1 (sep) + 1 (swatch) = len+2.
+        let sep1_idx = self.tool_buttons.len();
         let start = sep1_idx + 2;
 
         let container_child = self.container.first_child();

--- a/tests/geometry_tests.rs
+++ b/tests/geometry_tests.rs
@@ -27,7 +27,10 @@ fn snap_angle_snaps_to_nearest_45_degree_angle() {
     let snapped = snap_angle(start, end);
 
     let expected_len = (2.0_f64.powi(2) + 1.0_f64.powi(2)).sqrt();
-    let expected = Point(expected_len * std::f64::consts::FRAC_1_SQRT_2, expected_len * std::f64::consts::FRAC_1_SQRT_2);
+    let expected = Point(
+        expected_len * std::f64::consts::FRAC_1_SQRT_2,
+        expected_len * std::f64::consts::FRAC_1_SQRT_2,
+    );
     assert_point_close(snapped, expected);
 }
 


### PR DESCRIPTION
### Motivation
- Add low-cost, high-value checks to catch style drift and correctness issues early via `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings`.
- Ensure reproducible builds and faster CI runs by enforcing `--locked` on tests/builds and introducing dependency caching with `Swatinem/rust-cache@v2`.
- Validate the documented Nix developer environment and remove brittle build-from-main dependencies to reduce CI flakiness.

### Description
- Reworked `.github/workflows/rust.yml` into two focused jobs: `fedora-ci` (containerized checks) and `nix-ci` (Nix validation). 
- Upgraded checkout to `actions/checkout@v4` and added `Swatinem/rust-cache@v2` in both jobs to cache Rust artifacts. 
- Added `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test --locked --verbose`, and `cargo build --release --locked --verbose` to the `fedora-ci` job. 
- Replaced the unpinned `git clone` build-from-main flow with a package install of `gtk4-layer-shell-devel` and moved ephemeral `export` usage out of cross-step runs by simplifying job-level handling. 
- Added `nix-ci` job that runs `nix-shell --run "cargo test --locked"` to continuously validate the Nix dev environment.

### Testing
- No automated test runs were executed as part of this repo change; the updated workflow will run the new jobs on `push` and `pull_request` in CI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11f705a6d083259b6cf16e387c2508)